### PR TITLE
ci: hotfix docker-release by doing `npm install --legacy-peer-deps`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV DISCOVERY_POOL_SIZE=${DISCOVERY_POOL_SIZE}
 WORKDIR /app
 ADD package.json /app
 ADD package-lock.json /app
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 ADD . /app
 RUN npm run export


### PR DESCRIPTION
due to upstream changes out of our control, CI is failing as in https://github.com/vocdoni/explorer-ui/runs/6775601568?check_suite_focus=true#step:8:229 since about two weeks ago.

passing `--legacy-peer-deps` to `npm install` fixes it