### PR TITLE
Change filter name

### DIFF
--- a/components/pages/processes/components/process-filter.tsx
+++ b/components/pages/processes/components/process-filter.tsx
@@ -172,7 +172,7 @@ const ProcessStatusSelector = ({
           name="ALL"
         />
         <ButtonOption
-          label={i18n.t('processes.filter.status_selector.ended')}
+          label={i18n.t('processes.filter.status_selector.active')}
           name="RESULTS"
         />
         <ButtonOption

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -260,7 +260,8 @@
             "status_selector": {
                 "all": "",
                 "ended": "",
-                "paused": ""
+                "paused": "",
+                "active": ""
             }
         },
         "list": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -260,7 +260,8 @@
             "status_selector": {
                 "all": "All",
                 "ended": "Ended",
-                "paused": "Paused"
+                "paused": "Paused",
+                "active": "Active"
             }
         },
         "list": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -260,7 +260,8 @@
             "status_selector": {
                 "all": "",
                 "ended": "",
-                "paused": ""
+                "paused": "",
+                "active": ""
             }
         },
         "list": {


### PR DESCRIPTION
On process page list the filter selector has to elements calling "ended". The first one in reality use "RESULTS" filters, which is very similar to `haveResults` on old RPC API:

https://docs.vocdoni.io/architecture/services/gateway.html#get-process-list

