### PR TITLE
Fix copy button 

### DIFF
--- a/components/blocks/copy-button.tsx
+++ b/components/blocks/copy-button.tsx
@@ -34,7 +34,7 @@ export const CopyButton = ({
 
   return (
     <>
-      <div onClick={handleCopy}>
+      <div onClick={handleCopy} style={{ width: 'fit-content' }}>
         <IconContext.Provider
           value={{
             color: color ?? 'inherit',
@@ -108,8 +108,8 @@ const AlertWrapper = styled.div`
 
 const AlertContainer = styled.div<{ visible: boolean }>`
   position: absolute;
-  top: -35px;
-  left: 25px;
+  top: -45px;
+  right: 25px;
   z-index: 5010;
   font-size: 12px;
   background-color: ${({ theme }) => theme.lightBg};

--- a/components/blocks/copy-button.tsx
+++ b/components/blocks/copy-button.tsx
@@ -29,7 +29,7 @@ export const CopyButton = ({
     e.preventDefault();
     e.target.focus();
     copy(toCopy);
-    setCopiedMessage(copyMessage ?? i18n.t('copy.the_link_has_been_copied_to_the_clipboard'));
+    setCopiedMessage(copyMessage ?? i18n.t('copy.copied_to_the_clipboard'));
   };
 
   return (

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -56,7 +56,8 @@
     },
     "copy": {
         "hash_copied_to_the_clipboard": "",
-        "the_link_has_been_copied_to_the_clipboard": ""
+        "the_link_has_been_copied_to_the_clipboard": "",
+        "copied_to_the_clipboard": ""
     },
     "dashboard": {
         "loading": "",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -56,7 +56,8 @@
     },
     "copy": {
         "hash_copied_to_the_clipboard": "Hash copied to the clipboard",
-        "the_link_has_been_copied_to_the_clipboard": "The link has been copied to the clipboard"
+        "the_link_has_been_copied_to_the_clipboard": "The link has been copied to the clipboard",
+        "copied_to_the_clipboard":  "Copied to the clipboard"
     },
     "dashboard": {
         "loading": "Loading",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -56,7 +56,8 @@
     },
     "copy": {
         "hash_copied_to_the_clipboard": "",
-        "the_link_has_been_copied_to_the_clipboard": ""
+        "the_link_has_been_copied_to_the_clipboard": "",
+        "copied_to_the_clipboard": ""
     },
     "dashboard": {
         "loading": "",


### PR DESCRIPTION
- Use `width: fit-content`
- It fixes https://github.com/vocdoni/explorer-ui/issues/84 moving the alert over the text
- Use a more generic copy message 