### PR TITLE
Prevent empty array results

### DIFF
--- a/hooks/use-entities.tsx
+++ b/hooks/use-entities.tsx
@@ -17,7 +17,7 @@ export const useEntityList = ({
   const { setAlertMessage } = useAlertMessage();
   const { poolPromise } = usePool();
   const [entitiesList, setEntitiesList] = useState<string[]>();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const getEntityIDs = () => {
     const f = from < 0 ? 0 : from;


### PR DESCRIPTION
 Dvote-js is crashing when trying to refresh results on a 0 results election, this one:

https://stg.explorer.vote/processes/show/#/c5d2460186f738d2bc91b89928f78cbab3e4b1949e28787ec7a3020400000003

On the stg explorer you will see a client-side exception, but debugging locally I found that the line that crash is this one: 

https://github.com/vocdoni/dvote-js/blob/main/packages/voting/src/voting.ts#L316

With the exception of: 

```
TypeError: zippedEntry.result is undefined
```

I'm not sure if is an error of dvoteJs that should expects an object with undefined results, or is an error on backend side that is not returning properly the results object...

-----------

 I found that  `VotingApi.getResults(processId, pool)` is returning an empty array result and should be instead an array of arrays with a result for every choice.  

Also modifying dvote with this it also fixes the problem:

```ts
const zippedQuestions = metadata.questions.map((meta, idx) => ({ meta, result: results[idx] ?? 0 }))
```

We can just patch dvote to handle empty arrays or either check if is a regression backend-side.
Meanwhile i did a cutre-fix if we want to patch it on the explorer side:

