### PR TITLE
Prevent undefined args

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -3,9 +3,9 @@ import {
   ChainAPI,
   ClientOptions,
   ElectionAPI,
+  IChainBlockInfoResponse,
   VocdoniSDKClient,
   VoteAPI,
-  IChainBlockInfoResponse,
 } from '@vocdoni/sdk';
 
 export class ExtendedSDKClient extends VocdoniSDKClient {
@@ -50,10 +50,14 @@ export class ExtendedSDKClient extends VocdoniSDKClient {
       return blockInfo.reduce((prev, cur) => prev.concat(cur), []).reverse();
     });
   };
-  blockToDate = (height?: number) => ChainAPI.blockToDate(this.url, height);
-  dateToBlock = (date?: Date) => {
-    if (!date) date = new Date();
-    const epoch = Math.floor(date.getTime() / 1000);
-    return ChainAPI.dateToBlock(this.url, epoch);
+  blockToDate = (height?: number): ReturnType<typeof ChainAPI.blockToDate> => {
+    return height ? ChainAPI.blockToDate(this.url, height) : Promise.resolve({ date: undefined });
+  };
+  dateToBlock = (date?: Date): ReturnType<typeof ChainAPI.dateToBlock> => {
+    if (date) {
+      const epoch = Math.floor(date.getTime() / 1000);
+      return ChainAPI.dateToBlock(this.url, epoch);
+    }
+    return Promise.resolve({ height: undefined });
   };
 }


### PR DESCRIPTION
Before this, on the calculator view, when height or date were null the call to the API was made anyway.

On this way, the call is not made (avoiding errors), the `useSDKFunction` doesn't throw exception because the return type cannot be undefined, and on the view anything crashes due to the undefined checks.  