### PR TITLE
Prevent wrong vote package

### DIFF
--- a/components/pages/transactions/details/index.tsx
+++ b/components/pages/transactions/details/index.tsx
@@ -45,8 +45,13 @@ export const TransactionDetails = ({
     case 'vote': {
       const tx = txPayload['vote'] as VoteEnvelope;
       if (tx.votePackage) {
-        votePackage = Buffer.from(tx.votePackage, 'base64').toString('ascii');
-        (rawTx['tx']['vote'] as VoteEnvelope).votePackage = JSON.parse(votePackage);
+        try {
+          votePackage = Buffer.from(tx.votePackage, 'base64').toString('ascii');
+          (rawTx['tx']['vote'] as VoteEnvelope).votePackage = JSON.parse(votePackage);
+        } catch (e) {
+          // Prevent page crashing if votePackage is broken backend side
+          votePackage = i18n.t('transactions.error_decoding_vote_package');
+        }
       }
       belongsToProcess = b64ToHex(tx.processId);
       break;

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -314,6 +314,7 @@
             "transaction_not_found": "Transacció no trobada",
             "vote_package": "Paquet de vot"
         },
+        "error_decoding_vote_package": "Error decodificant el paquet del vot",
         "filter": {
             "search": "Cercar"
         },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -314,6 +314,7 @@
             "transaction_not_found": "Transaction not found",
             "vote_package": "Vote package"
         },
+        "error_decoding_vote_package": "Error decoding vote package",
         "filter": {
             "search": "Search"
         },

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -314,6 +314,7 @@
             "transaction_not_found": "Transacción no encontrada",
             "vote_package": "Paquete de voto"
         },
+        "error_decoding_vote_package": "Error decodificando el paquete de voto",
         "filter": {
             "search": "Buscar"
         },


### PR DESCRIPTION
We found a vote where the vote package was encoded wrong causing the crash on the explorer.

On this way, the explorer won't crash
