### PR TITLE
Fix font family fallback

### DIFF
--- a/components/elements-v2/text.tsx
+++ b/components/elements-v2/text.tsx
@@ -58,7 +58,6 @@ const styledConfig = {
   shouldForwardProp: (prop) => !cosmeticProps.includes(prop),
 };
 const BaseText = styled.span.withConfig(styledConfig)<TextProps>`
-  font-family: Manrope;
   font-size: ${getTextSize};
   font-weight: ${getTextWeight};
   color: ${getTextColor};

--- a/components/elements/button.tsx
+++ b/components/elements/button.tsx
@@ -343,7 +343,6 @@ export const HomePageButton = styled.button`
   color: white;
   border: none;
 
-  font-family: 'Manrope';
   font-style: normal;
   font-weight: 700;
   font-size: 16px;
@@ -351,7 +350,6 @@ export const HomePageButton = styled.button`
 
   a {
     color: white;
-    font-family: 'Manrope';
     font-style: normal;
     font-weight: 700;
     font-size: 16px;

--- a/components/pages/app/header.tsx
+++ b/components/pages/app/header.tsx
@@ -6,14 +6,14 @@ import { Unless } from 'react-if';
 import { useTranslation } from 'react-i18next';
 
 import {
+  BLOCKS_PATH,
   HOME_PATH,
   ORGANIZATIONS_PATH,
   PROCESSES_PATH,
-  BLOCKS_PATH,
-  TRANSACTIONS_PATH,
-  VALIDATORS_PATH,
   STATS_PATH,
   TOOLS_PATH,
+  TRANSACTIONS_PATH,
+  VALIDATORS_PATH,
   VERIFY,
 } from '@const/routes';
 
@@ -290,7 +290,6 @@ const CTAButton = ({ url, children }: ILinkItemProps) => {
 
 const CTA = styled(Link)`
   color: inherit;
-  font-family: 'Manrope';
   font-style: normal;
   font-weight: 700;
   font-size: 12.8px;


### PR DESCRIPTION
We found that on phones, some elections results are not displayed correctly:

![image](https://github.com/vocdoni/explorer-ui/assets/16777076/d32df322-af5c-4702-bf4b-c2a98f8306a5)

This could be provoked because a leak of fallback on the font family for the Text v2 component.

This PR delete the font family property to use the one defined by the `global.ts`:  https://github.com/vocdoni/explorer-ui/blob/ece0c783afecdf5d24e3097f02799693de96f2fd/theme/global.ts#L21